### PR TITLE
Replace Atom-Slime with SLIMA in IDE page

### DIFF
--- a/ides/summary.html
+++ b/ides/summary.html
@@ -14,7 +14,7 @@ layout: default
   <li><p><a href="http://www.cliki.net/MCLIDE">McClide</a> (OSX) - Maintained.</p></li>
   <li><p><a href="https://bitbucket.org/skolos/lispdev/overview">Cusp/Eclipse</a> - Unmaintained. <a href="cusp-setup.html">Articulate-Lisp cusp article</a></p></li>
   <li><p><a href="http://ufasoft.com/lisp/">Ufasoft</a> (Windows) - Unmaintained.</p></li>
-  <li><p><a href="https://atom.io/packages/atom-slime">Atom-SLIME</a> - Maintained. Integrates SLIME with Atom! This package allows you to interactively develop Common Lisp code, helping turn Atom into a full-featured Lisp IDE. </p></li>
+  <li><p><a href="https://atom.io/packages/SLIMA">SLIMA</a> - Maintained. Integrates SLIME with Atom! This package allows you to interactively develop Common Lisp code, helping turn Atom into a full-featured Lisp IDE. </p></li>
 </ul>
 <h2 id="non-open-source">Non-open source</h2>
 <ul>


### PR DESCRIPTION
Atom-Slime is no longer maintained (see right under the image in the readme: https://github.com/sjlevine/atom-slime).  [SLIMA](https://atom.io/packages/slima) is the maintained fork.