### PR TITLE
Correct Windows installation instructions

### DIFF
--- a/implementations/sbcl-setup.html
+++ b/implementations/sbcl-setup.html
@@ -36,7 +36,7 @@ information.</p>
 <h2 id="installing-on-windows">Installing on Windows</h2>
 <p> Install the Scoop package manager. To do this, open PowerShell and type: ' iex (new-object net.webclient).downloadstring('https://get.scoop.sh') ' (minus single quotes).
 Review the permissions for Scoop and and accept them if you are comfortable with them </p>
-<p> Type: scoop install curl (no special permissions needed!) into PowerShell, and you're all set! Restart the shell and you can start working in SBCL! </p>
+<p> Type: scoop install sbcl (no special permissions needed!) into PowerShell, and you're all set! Restart the shell and you can start working in SBCL! </p>
 
 <h2 id="further-installation-on-linuxosx">Further installation on Linux/OSX</h2>
 <p>Sometimes the SBCL you pick up from sbcl.org isn&#8217;t as feature-complete as you want, or perhaps you want to recompile it for your own reasons (i.e., the Hunchentoot web server requires threads).</p>


### PR DESCRIPTION
Noticed while reading that the instruction said to type 'scoop install curl', I figured this was supposed to say sbcl.